### PR TITLE
Add context

### DIFF
--- a/app/controllers/casino/sessions_controller.rb
+++ b/app/controllers/casino/sessions_controller.rb
@@ -21,7 +21,7 @@ class CASino::SessionsController < CASino::ApplicationController
   end
 
   def create
-    validation_result = validate_login_credentials(params[:username], params[:password])
+    validation_result = validate_login_credentials(params[:username], params[:password], params[:content])
     if !validation_result
       log_failed_login params[:username]
       show_login_error I18n.t('login_credential_acceptor.invalid_login_credentials')

--- a/app/controllers/casino/sessions_controller.rb
+++ b/app/controllers/casino/sessions_controller.rb
@@ -21,7 +21,7 @@ class CASino::SessionsController < CASino::ApplicationController
   end
 
   def create
-    validation_result = validate_login_credentials(params[:username], params[:password], params[:content])
+    validation_result = validate_login_credentials(params[:username], params[:password], current_authenticator_context)
     if !validation_result
       log_failed_login params[:username]
       show_login_error I18n.t('login_credential_acceptor.invalid_login_credentials')

--- a/app/helpers/casino/sessions_helper.rb
+++ b/app/helpers/casino/sessions_helper.rb
@@ -23,6 +23,10 @@ module CASino::SessionsHelper
     tgt.user
   end
 
+  def current_authenticator_context
+    CASino.config.authenticator_context_builder.call(params, request)
+  end
+  
   def ensure_signed_in
     redirect_to login_path unless signed_in?
   end

--- a/app/processors/casino/authentication_processor.rb
+++ b/app/processors/casino/authentication_processor.rb
@@ -3,7 +3,7 @@ require 'casino/authenticator'
 module CASino::AuthenticationProcessor
   extend ActiveSupport::Concern
 
-  def validate_login_credentials(username, password, context = {})
+  def validate_login_credentials(username, password, context = nil)
     authentication_result = nil
     authenticators.each do |authenticator_name, authenticator|
       begin

--- a/app/processors/casino/authentication_processor.rb
+++ b/app/processors/casino/authentication_processor.rb
@@ -3,11 +3,17 @@ require 'casino/authenticator'
 module CASino::AuthenticationProcessor
   extend ActiveSupport::Concern
 
-  def validate_login_credentials(username, password)
+  def validate_login_credentials(username, password, context = {})
     authentication_result = nil
     authenticators.each do |authenticator_name, authenticator|
       begin
-        data = authenticator.validate(username, password)
+        credentials = [ username, password, context ]
+
+        # Old authenticators that don't accept a 3rd context parameter will have a validate
+        # method that only accepts 2 arguments, so check for that.
+        credentials.pop if authenticator.class.instance_method(:validate).arity == 2
+
+        data = authenticator.validate(*credentials)
       rescue CASino::Authenticator::AuthenticatorError => e
         Rails.logger.error "Authenticator '#{authenticator_name}' (#{authenticator.class}) raised an error: #{e}"
       end

--- a/lib/casino.rb
+++ b/lib/casino.rb
@@ -6,6 +6,7 @@ module CASino
 
   defaults = {
     authenticators: HashWithIndifferentAccess.new,
+    authenticator_context_builder: ->(params, request){ },
     require_service_rules: false,
     logger: Rails.logger,
     frontend: HashWithIndifferentAccess.new(


### PR DESCRIPTION
This allows users to pass in a `context` object when validating credentials. This can include HTTP request data or anything else that might be important when validating a login.

The specific use case was to pass the subdomain in order to look up users that are segmented based on subdomain.